### PR TITLE
include `site.index[page.lang]` in the header link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 
   <div class="wrapper">
 
-    <a class="site-title" href="{{ site.baseurl }}/">{{ site.title[page.lang] }}</a>
+    <a class="site-title" href="{{ site.baseurl }}/{{ site.index[page.lang] }}">{{ site.title[page.lang] }}</a>
 
     <nav class="site-nav">
       <a href="#" class="menu-icon">


### PR DESCRIPTION
this change enables the link in a French page's header to be directed to the French index page. I tested on my own project but not on this repo.